### PR TITLE
UnicodeSequence and SingleEmoji now can handle null values in all compare operations

### DIFF
--- a/tests/CodepointTests.cs
+++ b/tests/CodepointTests.cs
@@ -1,8 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NeoSmart.Unicode;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace UnicodeTests
 {

--- a/tests/ConversionTests.cs
+++ b/tests/ConversionTests.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NeoSmart.Unicode;
 using System.Linq;
 using System.Text;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NeoSmart.Unicode;
 
 namespace UnicodeTests
 {

--- a/tests/EmojiTests.cs
+++ b/tests/EmojiTests.cs
@@ -11,14 +11,16 @@ namespace UnicodeTests
         public void TestEmojiCreation()
         {
             SingleEmoji FaceWithTearsOfJoy = new SingleEmoji(
-           sequence: new UnicodeSequence("1F602"),
-           name: "face with tears of joy",
-           searchTerms: new[] { "face", "tears", "joy" },
-           sortOrder: 2
+               sequence: new UnicodeSequence("1F602"),
+               name: "face with tears of joy",
+               searchTerms: new[] { "face", "tears", "joy" },
+               sortOrder: 2
             );
 
-            Assert.IsTrue(!(FaceWithTearsOfJoy is null));
-            Assert.IsFalse(Emoji.FaceWithTearsOfJoy is null);
+            Assert.IsTrue(FaceWithTearsOfJoy.Sequence.Codepoints.Count() == 1);
+            Assert.AreEqual(FaceWithTearsOfJoy.Sequence.Codepoints.First().ToString(), "U+1F602");
+            Assert.AreEqual(FaceWithTearsOfJoy.Name, "face with tears of joy");
+            Assert.IsTrue(FaceWithTearsOfJoy.SearchTerms.SequenceEqual(new[] { "face", "tears", "joy" }));
         }
 
         [TestMethod]
@@ -29,10 +31,10 @@ namespace UnicodeTests
         }
 
         [TestMethod]
-        public void VerifyNoNullEmoji()
+        public void VerifyNoEmptyEmoji()
         {
-            Assert.IsTrue(Emoji.All.All(e => !(e is null)));
-            Assert.IsTrue(Emoji.Basic.All(e => !(e is null)));
+            Assert.IsTrue(Emoji.All.All(e => !string.IsNullOrEmpty(e.Name)));
+            Assert.IsTrue(Emoji.Basic.All(e => !string.IsNullOrEmpty(e.Name)));
         }
 
         [TestMethod]

--- a/tests/EmojiTests.cs
+++ b/tests/EmojiTests.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NeoSmart.Unicode;
+using System.Linq;
 
 namespace UnicodeTests
 {
@@ -46,20 +45,20 @@ namespace UnicodeTests
         [TestMethod]
         public void TestEmojiDetection()
         {
-            string[] singularEmoji = new []
+            string[] singularEmoji = new[]
             {
                 "😀",
                 "👺",
                 "😶"
             };
 
-            string[] combinedEmoji = new []
+            string[] combinedEmoji = new[]
             {
                 "👩‍🔧",
                 "👩‍🔬"
             };
 
-            string[] threeEmojiSymbols = new []
+            string[] threeEmojiSymbols = new[]
             {
                 "😀😀😀",
                 "👩‍🔧😀😀",
@@ -67,7 +66,7 @@ namespace UnicodeTests
                 "👩‍🔧👩‍🔧👩‍🔧"
             };
 
-            string[] mixedEmojiDigits = new []
+            string[] mixedEmojiDigits = new[]
             {
                 "😀12",
                 "1😀2",
@@ -81,7 +80,7 @@ namespace UnicodeTests
                 "ab😀"
             };
 
-            string[] nonEmojiText = new []
+            string[] nonEmojiText = new[]
             {
                 "123",
                 "abc",

--- a/tests/SequenceTests.cs
+++ b/tests/SequenceTests.cs
@@ -1,8 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NeoSmart.Unicode;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Linq;
 
 namespace UnicodeTests
@@ -21,12 +18,52 @@ namespace UnicodeTests
             Assert.AreEqual(_swimmer.AsString, _swimmerString);
             Assert.IsTrue(_swimmer.Codepoints.SequenceEqual(_swimmerString.Codepoints()));
             Assert.AreEqual(_femaleSwimmer.AsString, _femaleSwimmerString);
+
+            Assert.IsFalse(_swimmer.Equals((UnicodeSequence)null));
+            Assert.IsFalse(_swimmer.Equals((string)null));
+            Assert.IsTrue(_swimmer.Equals(_swimmer));
+
+            Assert.IsFalse(Equals(_swimmer, null));
+            Assert.IsTrue(Equals(_swimmer, _swimmer));
+
+            Assert.IsFalse(_swimmer.Equals(null, _femaleSwimmer));
+            Assert.IsFalse(_swimmer.Equals(_femaleSwimmer, null));
+            Assert.IsTrue(_swimmer.Equals(_femaleSwimmer, _femaleSwimmer));
         }
 
         [TestMethod]
         public void TestSequenceMembership()
         {
             Assert.IsTrue(_femaleSwimmer.Contains(_swimmer.Codepoints.First()));
+        }
+
+        [TestMethod]
+        public void TestSequenceCompareTo()
+        {
+            Assert.IsTrue(_swimmer.CompareTo(_femaleSwimmer) != 0);
+            Assert.IsTrue(_swimmer.CompareTo(_swimmer) == 0);
+        }
+
+        [TestMethod]
+        public void TestSequenceSame()
+        {
+            Assert.IsFalse(_swimmer == null);
+            Assert.IsFalse(null == _swimmer);
+            Assert.IsFalse(_swimmer == _femaleSwimmer);
+#pragma warning disable CS1718 // Comparison made to same variable
+            Assert.IsTrue(_swimmer == _swimmer);
+#pragma warning restore CS1718 // Comparison made to same variable
+        }
+
+        [TestMethod]
+        public void TestSequenceNotSame()
+        {
+            Assert.IsTrue(_swimmer != null);
+            Assert.IsTrue(null != _swimmer);
+            Assert.IsTrue(_swimmer != _femaleSwimmer);
+#pragma warning disable CS1718 // Comparison made to same variable
+            Assert.IsFalse(_swimmer != _swimmer);
+#pragma warning restore CS1718 // Comparison made to same variable
         }
     }
 }

--- a/tests/SingleEmojiTests.cs
+++ b/tests/SingleEmojiTests.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NeoSmart.Unicode;
+
+namespace UnicodeTests
+{
+    [TestClass]
+    public class SingleEmojiTests
+    {
+        [TestMethod]
+        public void TestSingleEmojiSame()
+        {
+            Assert.IsFalse(Emoji.AbButtonBloodType == null);
+            Assert.IsFalse(null == Emoji.AbButtonBloodType);
+            Assert.IsFalse(Emoji.AbButtonBloodType == Emoji.Adult);
+#pragma warning disable CS1718 // Comparison made to same variable
+            Assert.IsTrue(Emoji.AbButtonBloodType == Emoji.AbButtonBloodType);
+#pragma warning restore CS1718 // Comparison made to same variable
+        }
+
+        [TestMethod]
+        public void TestSingleEmojiNotSame()
+        {
+            Assert.IsTrue(Emoji.AbButtonBloodType != null);
+            Assert.IsTrue(null != Emoji.AbButtonBloodType);
+            Assert.IsTrue(Emoji.AbButtonBloodType != Emoji.Adult);
+#pragma warning disable CS1718 // Comparison made to same variable
+            Assert.IsFalse(Emoji.AbButtonBloodType != Emoji.AbButtonBloodType);
+#pragma warning restore CS1718 // Comparison made to same variable
+        }
+
+        [TestMethod]
+        public void TestSingleEmojiEquality()
+        {
+            Assert.IsFalse(Emoji.AbButtonBloodType.Equals(null));
+            Assert.IsTrue(Emoji.AbButtonBloodType.Equals(Emoji.AbButtonBloodType));
+
+            Assert.IsFalse(Equals(Emoji.AbButtonBloodType, null));
+            Assert.IsTrue(Equals(Emoji.AbButtonBloodType, Emoji.AbButtonBloodType));
+
+            Assert.IsFalse(Emoji.AbButtonBloodType.Equals(null, Emoji.Adult));
+            Assert.IsFalse(Emoji.AbButtonBloodType.Equals(Emoji.Adult, null));
+            Assert.IsTrue(Emoji.AbButtonBloodType.Equals(Emoji.Adult, Emoji.Adult));
+        }
+
+        [TestMethod]
+        public void TestSingleEmojiCompareTo()
+        {
+            Assert.IsFalse(Emoji.AbButtonBloodType.CompareTo(Emoji.AbButtonBloodType) != 0);
+        }
+    }
+}

--- a/tests/SingleEmojiTests.cs
+++ b/tests/SingleEmojiTests.cs
@@ -37,8 +37,6 @@ namespace UnicodeTests
             Assert.IsFalse(Equals(Emoji.AbButtonBloodType, null));
             Assert.IsTrue(Equals(Emoji.AbButtonBloodType, Emoji.AbButtonBloodType));
 
-            Assert.IsFalse(Emoji.AbButtonBloodType.Equals(null, Emoji.Adult));
-            Assert.IsFalse(Emoji.AbButtonBloodType.Equals(Emoji.Adult, null));
             Assert.IsTrue(Emoji.AbButtonBloodType.Equals(Emoji.Adult, Emoji.Adult));
         }
 

--- a/unicode/Codepoint.cs
+++ b/unicode/Codepoint.cs
@@ -6,18 +6,18 @@ using System.Text;
 
 namespace NeoSmart.Unicode
 {
-    public struct Codepoint : IComparable<Codepoint>, IComparable<uint>, IEquatable<Codepoint>,
+    public struct Codepoint : IComparable<Codepoint>, IComparable<UInt32>, IEquatable<Codepoint>,
         IEquatable<string>, IComparable<string>, IEquatable<char>
     {
-        public readonly uint Value;
+        public readonly UInt32 Value;
 
-        public Codepoint(uint value)
+        public Codepoint(UInt32 value)
         {
             Value = value;
         }
 
         public Codepoint(long value)
-            : this((uint)value)
+            : this((UInt32)value)
         { }
 
         /// <summary>
@@ -30,13 +30,13 @@ namespace NeoSmart.Unicode
             {
                 hexValue = hexValue.Substring(2);
             }
-            if (!uint.TryParse(hexValue, NumberStyles.HexNumber, CultureInfo.CurrentCulture.NumberFormat, out Value))
+            if (!UInt32.TryParse(hexValue, NumberStyles.HexNumber, CultureInfo.CurrentCulture.NumberFormat, out Value))
             {
                 throw new UnsupportedCodepointException();
             }
         }
 
-        public uint AsUtf32() => Value;
+        public UInt32 AsUtf32() => Value;
 
         /// <summary>
         /// Returns an iterator that will enumerate over the big endian bytes in the UTF32 encoding of this codepoint.
@@ -49,29 +49,29 @@ namespace NeoSmart.Unicode
             yield return b1;
             var b2 = (byte)((utf32 & 0x00FFFFFF) >> 16);
             yield return b2;
-            var b3 = (byte)(((ushort)utf32) >> 8);
+            var b3 = (byte)(((UInt16)utf32) >> 8);
             yield return b3;
             var b4 = (byte)utf32;
             yield return b4;
         }
 
         //https://en.wikipedia.org/wiki/UTF-16
-        public IEnumerable<ushort> AsUtf16()
+        public IEnumerable<UInt16> AsUtf16()
         {
             //U+0000 to U+D7FF and U+E000 to U+FFFF
             if (Value <= 0xFFFF)
             {
-                yield return (ushort)Value;
+                yield return (UInt16)Value;
             }
             //U+10000 to U+10FFFF
             else if (Value >= 0x10000 && Value <= 0x10FFFF)
             {
-                uint newVal = Value - 0x010000; //leaving 20 bits
-                ushort high = (ushort)((newVal >> 10) + 0xD800);
+                UInt32 newVal = Value - 0x010000; //leaving 20 bits
+                UInt16 high = (UInt16)((newVal >> 10) + 0xD800);
                 System.Diagnostics.Debug.Assert(high <= 0xDBFF && high >= 0xD800);
                 yield return high;
 
-                ushort low = (ushort)((newVal & 0x03FF) + 0xDC00);
+                UInt16 low = (UInt16)((newVal & 0x03FF) + 0xDC00);
                 System.Diagnostics.Debug.Assert(low <= 0xDFFF && low >= 0xDC00);
                 yield return low;
             }
@@ -141,7 +141,7 @@ namespace NeoSmart.Unicode
             return Value.CompareTo(other.Value);
         }
 
-        public int CompareTo(uint other)
+        public int CompareTo(UInt32 other)
         {
             return Value.CompareTo(other);
         }
@@ -195,12 +195,12 @@ namespace NeoSmart.Unicode
             return a.Value <= b.Value;
         }
 
-        public static implicit operator uint(Codepoint codepoint)
+        public static implicit operator UInt32(Codepoint codepoint)
         {
             return codepoint.Value;
         }
 
-        public static implicit operator Codepoint(uint value)
+        public static implicit operator Codepoint(UInt32 value)
         {
             return new Codepoint(value);
         }

--- a/unicode/Codepoint.cs
+++ b/unicode/Codepoint.cs
@@ -1,23 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Linq;
 using System.Globalization;
+using System.Linq;
+using System.Text;
 
 namespace NeoSmart.Unicode
 {
-    public struct Codepoint : IComparable<Codepoint>, IComparable<UInt32>, IEquatable<Codepoint>, 
+    public struct Codepoint : IComparable<Codepoint>, IComparable<uint>, IEquatable<Codepoint>,
         IEquatable<string>, IComparable<string>, IEquatable<char>
     {
-        public readonly UInt32 Value;
+        public readonly uint Value;
 
-        public Codepoint(UInt32 value)
+        public Codepoint(uint value)
         {
             Value = value;
         }
 
         public Codepoint(long value)
-            : this ((UInt32) value)
+            : this((uint)value)
         { }
 
         /// <summary>
@@ -45,13 +45,13 @@ namespace NeoSmart.Unicode
         {
             //from highest to lowest
             var utf32 = AsUtf32();
-            var b1 = (byte) (utf32 >> 24);
+            var b1 = (byte)(utf32 >> 24);
             yield return b1;
-            var b2 = (byte) ((utf32 & 0x00FFFFFF) >> 16);
+            var b2 = (byte)((utf32 & 0x00FFFFFF) >> 16);
             yield return b2;
-            var b3 = (byte) (((UInt16) utf32) >> 8);
+            var b3 = (byte)(((ushort)utf32) >> 8);
             yield return b3;
-            var b4 = (byte) utf32;
+            var b4 = (byte)utf32;
             yield return b4;
         }
 
@@ -61,17 +61,17 @@ namespace NeoSmart.Unicode
             //U+0000 to U+D7FF and U+E000 to U+FFFF
             if (Value <= 0xFFFF)
             {
-                yield return (UInt16) Value;
+                yield return (ushort)Value;
             }
             //U+10000 to U+10FFFF
             else if (Value >= 0x10000 && Value <= 0x10FFFF)
             {
-                UInt32 newVal = Value - 0x010000; //leaving 20 bits
-                UInt16 high = (UInt16) ((newVal >> 10) + 0xD800);
+                uint newVal = Value - 0x010000; //leaving 20 bits
+                ushort high = (ushort)((newVal >> 10) + 0xD800);
                 System.Diagnostics.Debug.Assert(high <= 0xDBFF && high >= 0xD800);
                 yield return high;
 
-                UInt16 low = (UInt16) ((newVal & 0x03FF) + 0xDC00);
+                ushort low = (ushort)((newVal & 0x03FF) + 0xDC00);
                 System.Diagnostics.Debug.Assert(low <= 0xDFFF && low >= 0xDC00);
                 yield return low;
             }
@@ -89,9 +89,9 @@ namespace NeoSmart.Unicode
             var utf16 = AsUtf16();
             foreach (var u16 in utf16)
             {
-                var high = (byte) (u16 >> 8);
+                var high = (byte)(u16 >> 8);
                 yield return high;
-                var low = (byte) u16;
+                var low = (byte)u16;
                 yield return low;
             }
         }
@@ -102,34 +102,34 @@ namespace NeoSmart.Unicode
             //up to 7 bits
             if (Value <= 0x007F)
             {
-                yield return (byte) Value;
+                yield return (byte)Value;
                 yield break;
             }
 
             //up to 11 bits
             if (Value <= 0x07FF)
             {
-                yield return (byte) (0b11000000 | (0b00011111 & (Value >> 6))); //tag + upper 5 bits
-                yield return (byte) (0b10000000 | (0b00111111 & Value)); //tag + lower 6 bits
+                yield return (byte)(0b11000000 | (0b00011111 & (Value >> 6))); //tag + upper 5 bits
+                yield return (byte)(0b10000000 | (0b00111111 & Value)); //tag + lower 6 bits
                 yield break;
             }
 
             //up to 16 bits
             if (Value <= 0x0FFFF)
             {
-                yield return (byte) (0b11100000 | (0b00001111 & (Value >> 12))); //tag + upper 4 bits
-                yield return (byte) (0b10000000 | (0b00111111 & (Value >> 6))); //tag + next 6 bits
-                yield return (byte) (0b10000000 | (0b00111111 & Value)); //tag + last 6 bits
+                yield return (byte)(0b11100000 | (0b00001111 & (Value >> 12))); //tag + upper 4 bits
+                yield return (byte)(0b10000000 | (0b00111111 & (Value >> 6))); //tag + next 6 bits
+                yield return (byte)(0b10000000 | (0b00111111 & Value)); //tag + last 6 bits
                 yield break;
             }
 
             //up to 21 bits
             if (Value <= 0x1FFFFF)
             {
-                yield return (byte) (0b11110000 | (0b00000111 & (Value >> 18))); //tag + upper 3 bits
-                yield return (byte) (0b10000000 | (0b00111111 & (Value >> 12))); //tag + next 6 bits
-                yield return (byte) (0b10000000 | (0b00111111 & (Value >> 6))); //tag + next 6 bits
-                yield return (byte) (0b10000000 | (0b00111111 & Value)); //tag + last 6 bits
+                yield return (byte)(0b11110000 | (0b00000111 & (Value >> 18))); //tag + upper 3 bits
+                yield return (byte)(0b10000000 | (0b00111111 & (Value >> 12))); //tag + next 6 bits
+                yield return (byte)(0b10000000 | (0b00111111 & (Value >> 6))); //tag + next 6 bits
+                yield return (byte)(0b10000000 | (0b00111111 & Value)); //tag + last 6 bits
                 yield break;
             }
 
@@ -141,7 +141,7 @@ namespace NeoSmart.Unicode
             return Value.CompareTo(other.Value);
         }
 
-        public int CompareTo(UInt32 other)
+        public int CompareTo(uint other)
         {
             return Value.CompareTo(other);
         }
@@ -165,12 +165,12 @@ namespace NeoSmart.Unicode
             return Value.GetHashCode();
         }
 
-        public static bool operator== (Codepoint a, Codepoint b)
+        public static bool operator ==(Codepoint a, Codepoint b)
         {
             return a.Value == b.Value;
         }
 
-        public static bool operator!= (Codepoint a, Codepoint b)
+        public static bool operator !=(Codepoint a, Codepoint b)
         {
             return a.Value != b.Value;
         }
@@ -195,12 +195,12 @@ namespace NeoSmart.Unicode
             return a.Value <= b.Value;
         }
 
-        public static implicit operator UInt32(Codepoint codepoint)
+        public static implicit operator uint(Codepoint codepoint)
         {
             return codepoint.Value;
         }
 
-        public static implicit operator Codepoint(UInt32 value)
+        public static implicit operator Codepoint(uint value)
         {
             return new Codepoint(value);
         }

--- a/unicode/Codepoints.cs
+++ b/unicode/Codepoints.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace NeoSmart.Unicode
+﻿namespace NeoSmart.Unicode
 {
     /// <summary>
     /// Helpful definitions for commonly- and not-so-commonly-used codepoints.

--- a/unicode/Emoji-All.cs
+++ b/unicode/Emoji-All.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Linq;
+﻿using System.Collections.Generic;
 
 namespace NeoSmart.Unicode
 {
@@ -9,7 +6,7 @@ namespace NeoSmart.Unicode
     //see importers/emoji-importer.html for the generator
     public static partial class Emoji
     {
-        public static IEnumerable<SingleEmoji> All => new [] {
+        public static IEnumerable<SingleEmoji> All => new[] {
 	        /* 😀 */ GrinningFace,
 	        /* 😁 */ GrinningFaceWithSmilingEyes,
 	        /* 😂 */ FaceWithTearsOfJoy,

--- a/unicode/Emoji-Basic.cs
+++ b/unicode/Emoji-Basic.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Linq;
+﻿using System.Collections.Generic;
 
 namespace NeoSmart.Unicode
 {
@@ -11,7 +8,7 @@ namespace NeoSmart.Unicode
         /// A (sorted) enumeration of all emoji without skin variations and no duplicate gendered vs gender-neutral emoji, ideal for displaying.
         /// Emoji without supported glyphs in Segoe UI Emoji are also omitted from this list.
         /// </summary>
-        public static IEnumerable<SingleEmoji> Basic => new [] {
+        public static IEnumerable<SingleEmoji> Basic => new[] {
 	        /* 😀 */ GrinningFace,
 	        /* 😁 */ GrinningFaceWithSmilingEyes,
 	        /* 😂 */ FaceWithTearsOfJoy,

--- a/unicode/Emoji-Emojis.cs
+++ b/unicode/Emoji-Emojis.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace NeoSmart.Unicode
+﻿namespace NeoSmart.Unicode
 {
     //this file is machine-generated from the official Unicode Consortium UTR51 publication
     //see importers/emoji-importer.html for the generator

--- a/unicode/Emoji.cs
+++ b/unicode/Emoji.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace NeoSmart.Unicode

--- a/unicode/Exceptions.cs
+++ b/unicode/Exceptions.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace NeoSmart.Unicode
 {

--- a/unicode/Languages-Emoji.cs
+++ b/unicode/Languages-Emoji.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace NeoSmart.Unicode
+﻿namespace NeoSmart.Unicode
 {
     public partial class Languages
     {

--- a/unicode/Languages.cs
+++ b/unicode/Languages.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace NeoSmart.Unicode
+﻿namespace NeoSmart.Unicode
 {
     public partial class Languages
     {

--- a/unicode/MultiRange.cs
+++ b/unicode/MultiRange.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace NeoSmart.Unicode
@@ -10,7 +8,7 @@ namespace NeoSmart.Unicode
         private List<Range> _ranges = new List<Range>();
         public IEnumerable<Range> Ranges => _ranges;
 
-        public MultiRange(params string[]  ranges)
+        public MultiRange(params string[] ranges)
         {
             _ranges.AddRange(ranges.Select(r => new Range(r)));
         }

--- a/unicode/Range.cs
+++ b/unicode/Range.cs
@@ -29,7 +29,7 @@ namespace NeoSmart.Unicode
         public Range(string range)
         {
             var values = range.Split(new[] { "-", "–", "—", ".." }, StringSplitOptions.RemoveEmptyEntries); //these are all different hyphens used on Wikipedia and in the UTR
-            Begin = uint.Parse(values[0], System.Globalization.NumberStyles.HexNumber);
+            Begin = UInt32.Parse(values[0], System.Globalization.NumberStyles.HexNumber);
 
             if (values.Length == 1)
             {
@@ -37,7 +37,7 @@ namespace NeoSmart.Unicode
             }
             else if (values.Length == 2)
             {
-                End = uint.Parse(values[1], System.Globalization.NumberStyles.HexNumber);
+                End = UInt32.Parse(values[1], System.Globalization.NumberStyles.HexNumber);
             }
             else
             {
@@ -45,18 +45,18 @@ namespace NeoSmart.Unicode
             }
         }
 
-        public IEnumerable<uint> AsUtf32Sequence
+        public IEnumerable<UInt32> AsUtf32Sequence
         {
             get
             {
-                for (uint i = 0; Begin + i <= End; ++i)
+                for (UInt32 i = 0; Begin + i <= End; ++i)
                 {
                     yield return new Codepoint(Begin + i).AsUtf32();
                 }
             }
         }
 
-        public IEnumerable<ushort> AsUtf16Sequence
+        public IEnumerable<UInt16> AsUtf16Sequence
         {
             get
             {

--- a/unicode/Range.cs
+++ b/unicode/Range.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Text;
 
 namespace NeoSmart.Unicode
 {
@@ -15,7 +13,7 @@ namespace NeoSmart.Unicode
             Begin = begin;
             End = end;
         }
-                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+
         public Range(Codepoint value)
         {
             Begin = value;
@@ -30,8 +28,8 @@ namespace NeoSmart.Unicode
         //either a single hex codepoint or two separated by a hyphen
         public Range(string range)
         {
-            var values = range.Split(new [] { "-", "–", "—", ".." }, StringSplitOptions.RemoveEmptyEntries); //these are all different hyphens used on Wikipedia and in the UTR
-            Begin = UInt32.Parse(values[0], System.Globalization.NumberStyles.HexNumber);
+            var values = range.Split(new[] { "-", "–", "—", ".." }, StringSplitOptions.RemoveEmptyEntries); //these are all different hyphens used on Wikipedia and in the UTR
+            Begin = uint.Parse(values[0], System.Globalization.NumberStyles.HexNumber);
 
             if (values.Length == 1)
             {
@@ -39,7 +37,7 @@ namespace NeoSmart.Unicode
             }
             else if (values.Length == 2)
             {
-                End = UInt32.Parse(values[1], System.Globalization.NumberStyles.HexNumber);
+                End = uint.Parse(values[1], System.Globalization.NumberStyles.HexNumber);
             }
             else
             {
@@ -47,18 +45,18 @@ namespace NeoSmart.Unicode
             }
         }
 
-        public IEnumerable<UInt32> AsUtf32Sequence
+        public IEnumerable<uint> AsUtf32Sequence
         {
             get
             {
-                for (UInt32 i = 0; Begin + i <= End; ++i)
+                for (uint i = 0; Begin + i <= End; ++i)
                 {
                     yield return new Codepoint(Begin + i).AsUtf32();
                 }
             }
         }
 
-        public IEnumerable<UInt16> AsUtf16Sequence
+        public IEnumerable<ushort> AsUtf16Sequence
         {
             get
             {

--- a/unicode/SingleEmoji.cs
+++ b/unicode/SingleEmoji.cs
@@ -7,7 +7,7 @@ namespace NeoSmart.Unicode
 {
     //We hereby declare emoji to be a zero plural marker noun (in short, "emoji" is both the singular and the plural form)
     //this class refers to emoji in the singular
-    public class SingleEmoji : IEqualityComparer<SingleEmoji>, IComparable<SingleEmoji>
+    public class SingleEmoji : IEqualityComparer<SingleEmoji>, IComparable<SingleEmoji>, IEquatable<SingleEmoji>
     {
         public readonly UnicodeSequence Sequence;
         public readonly string Name;
@@ -64,6 +64,11 @@ namespace NeoSmart.Unicode
         public override string ToString()
         {
             return Encoding.Unicode.GetString(Sequence.AsUtf16Bytes().ToArray());
+        }
+
+        public bool Equals(SingleEmoji other)
+        {
+            return !(other is null) && Equals(this, other);
         }
     }
 }

--- a/unicode/SingleEmoji.cs
+++ b/unicode/SingleEmoji.cs
@@ -7,7 +7,7 @@ namespace NeoSmart.Unicode
 {
     //We hereby declare emoji to be a zero plural marker noun (in short, "emoji" is both the singular and the plural form)
     //this class refers to emoji in the singular
-    public class SingleEmoji : IEqualityComparer<SingleEmoji>, IComparable<SingleEmoji>, IEquatable<SingleEmoji>
+    public struct SingleEmoji : IEqualityComparer<SingleEmoji>, IComparable<SingleEmoji>, IEquatable<SingleEmoji>
     {
         public readonly UnicodeSequence Sequence;
         public readonly string Name;
@@ -29,7 +29,7 @@ namespace NeoSmart.Unicode
 
         public bool Equals(SingleEmoji a, SingleEmoji b)
         {
-            return (a is null && b is null) || (!(a is null || b is null) && a.Sequence.Equals(b.Sequence));
+            return a.Sequence.Equals(b.Sequence);
         }
 
         public int GetHashCode(SingleEmoji obj)
@@ -39,7 +39,7 @@ namespace NeoSmart.Unicode
 
         public static bool operator ==(SingleEmoji a, SingleEmoji b)
         {
-            return (a is null && b is null) || (!(a is null || b is null) && a.Sequence == b.Sequence);
+            return a.Sequence == b.Sequence;
         }
 
         public static bool operator !=(SingleEmoji a, SingleEmoji b)
@@ -68,7 +68,7 @@ namespace NeoSmart.Unicode
 
         public bool Equals(SingleEmoji other)
         {
-            return !(other is null) && Equals(this, other);
+            return Equals(this, other);
         }
     }
 }

--- a/unicode/SingleEmoji.cs
+++ b/unicode/SingleEmoji.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Linq;
+using System.Text;
 
 namespace NeoSmart.Unicode
 {
@@ -29,29 +29,29 @@ namespace NeoSmart.Unicode
 
         public bool Equals(SingleEmoji x, SingleEmoji y)
         {
-            return Sequence == y.Sequence;
+            return (x is null && y is null) || (!(x is null || y is null) && x.Sequence.Equals(y.Sequence));
         }
 
         public int GetHashCode(SingleEmoji obj)
         {
-            return Sequence.GetHashCode();
+            return obj.GetHashCode();
         }
 
-        public static bool operator==(SingleEmoji a, SingleEmoji b)
+        public static bool operator ==(SingleEmoji x, SingleEmoji y)
         {
-            return a.Sequence == b.Sequence;
+            return (x is null && y is null) || (!(x is null || y is null) && x.Sequence == y.Sequence);
         }
 
-        public static bool operator !=(SingleEmoji a, SingleEmoji b)
+        public static bool operator !=(SingleEmoji x, SingleEmoji y)
         {
-            return a.Sequence != b.Sequence;
+            return !(x == y);
         }
 
         public override bool Equals(object obj)
         {
-            if (obj is SingleEmoji)
+            if (obj is SingleEmoji emoji)
             {
-                return Equals(this, obj as SingleEmoji);
+                return Equals(this, emoji);
             }
             return base.Equals(obj);
         }

--- a/unicode/SingleEmoji.cs
+++ b/unicode/SingleEmoji.cs
@@ -27,9 +27,9 @@ namespace NeoSmart.Unicode
             return SortOrder.CompareTo(other.SortOrder);
         }
 
-        public bool Equals(SingleEmoji x, SingleEmoji y)
+        public bool Equals(SingleEmoji a, SingleEmoji b)
         {
-            return (x is null && y is null) || (!(x is null || y is null) && x.Sequence.Equals(y.Sequence));
+            return (a is null && b is null) || (!(a is null || b is null) && a.Sequence.Equals(b.Sequence));
         }
 
         public int GetHashCode(SingleEmoji obj)
@@ -37,14 +37,14 @@ namespace NeoSmart.Unicode
             return obj.GetHashCode();
         }
 
-        public static bool operator ==(SingleEmoji x, SingleEmoji y)
+        public static bool operator ==(SingleEmoji a, SingleEmoji b)
         {
-            return (x is null && y is null) || (!(x is null || y is null) && x.Sequence == y.Sequence);
+            return (a is null && b is null) || (!(a is null || b is null) && a.Sequence == b.Sequence);
         }
 
-        public static bool operator !=(SingleEmoji x, SingleEmoji y)
+        public static bool operator !=(SingleEmoji a, SingleEmoji b)
         {
-            return !(x == y);
+            return !(a == b);
         }
 
         public override bool Equals(object obj)

--- a/unicode/StringExtension.cs
+++ b/unicode/StringExtension.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace NeoSmart.Unicode
 {
@@ -16,7 +15,7 @@ namespace NeoSmart.Unicode
                     {
                         throw new InvalidEncodingException();
                     }
-                    if (!char.IsLowSurrogate(s[i+1]))
+                    if (!char.IsLowSurrogate(s[i + 1]))
                     {
                         throw new InvalidEncodingException();
                     }

--- a/unicode/UnicodeSequence.cs
+++ b/unicode/UnicodeSequence.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace NeoSmart.Unicode
@@ -10,9 +10,9 @@ namespace NeoSmart.Unicode
     /// </summary>
     public class UnicodeSequence : IComparable<UnicodeSequence>, IEquatable<UnicodeSequence>, IEquatable<string>
     {
-        readonly Codepoint[] _codepoints;
+        private readonly Codepoint[] _codepoints;
         public IEnumerable<Codepoint> Codepoints => _codepoints;
-        
+
         private UnicodeSequence()
         {
 
@@ -73,10 +73,10 @@ namespace NeoSmart.Unicode
             foreach (var u32 in AsUtf32())
             {
                 //little endian byte order
-                yield return (byte) (u32 & 0xFF);
-                yield return (byte) ((u32 >> 8) & 0xFF);
-                yield return (byte) ((u32 >> 16) & 0xFF);
-                yield return (byte) (u32 >> 24);
+                yield return (byte)(u32 & 0xFF);
+                yield return (byte)((u32 >> 8) & 0xFF);
+                yield return (byte)((u32 >> 16) & 0xFF);
+                yield return (byte)(u32 >> 24);
             }
         }
 
@@ -96,8 +96,8 @@ namespace NeoSmart.Unicode
             foreach (var us in AsUtf16())
             {
                 //little endian byte order
-                yield return (byte) (us & 0xFF);
-                yield return (byte) (us >> 8);
+                yield return (byte)(us & 0xFF);
+                yield return (byte)(us >> 8);
             }
         }
 
@@ -158,14 +158,21 @@ namespace NeoSmart.Unicode
             return true;
         }
 
-        public static bool operator== (UnicodeSequence a, UnicodeSequence b)
+        public static bool operator ==(UnicodeSequence a, UnicodeSequence b)
         {
-            return a.Equals(b);
+            if (a is null)
+            {
+                return a == b || b.Equals(a);
+            }
+            else
+            {
+                return a.Equals(b);
+            }
         }
-        
-        public static bool operator!= (UnicodeSequence a, UnicodeSequence b)
+
+        public static bool operator !=(UnicodeSequence a, UnicodeSequence b)
         {
-            return !a.Equals(b);
+            return !(a == b);
         }
 
         public override bool Equals(object b)

--- a/unicode/UnicodeSequence.cs
+++ b/unicode/UnicodeSequence.cs
@@ -142,7 +142,7 @@ namespace NeoSmart.Unicode
                 return true;
             }
 
-            if (_codepoints.Length != other._codepoints.Length)
+            if (other is null || _codepoints.Length != other._codepoints.Length)
             {
                 return false;
             }
@@ -158,16 +158,9 @@ namespace NeoSmart.Unicode
             return true;
         }
 
-        public static bool operator ==(UnicodeSequence a, UnicodeSequence b)
+        public static bool operator ==(UnicodeSequence x, UnicodeSequence y)
         {
-            if (a is null)
-            {
-                return a == b || b.Equals(a);
-            }
-            else
-            {
-                return a.Equals(b);
-            }
+            return (x is null && y is null) || (!(x is null || y is null) && x.Equals(y));
         }
 
         public static bool operator !=(UnicodeSequence a, UnicodeSequence b)
@@ -184,6 +177,11 @@ namespace NeoSmart.Unicode
             return base.Equals(b);
         }
 
+        public bool Equals(UnicodeSequence x, UnicodeSequence y)
+        {
+            return (x is null && y is null) || (!(x is null || y is null) && x.Equals(y));
+        }
+
         public override int GetHashCode()
         {
             return _codepoints.GetHashCode();
@@ -191,7 +189,7 @@ namespace NeoSmart.Unicode
 
         public bool Equals(string other)
         {
-            return other.Codepoints().SequenceEqual(_codepoints);
+            return !(other is null) && other.Codepoints().SequenceEqual(_codepoints);
         }
     }
 }

--- a/unicode/UnicodeSequence.cs
+++ b/unicode/UnicodeSequence.cs
@@ -8,7 +8,7 @@ namespace NeoSmart.Unicode
     /// <summary>
     /// A UnicodeSequence is a combination of one or more codepoints.
     /// </summary>
-    public class UnicodeSequence : IComparable<UnicodeSequence>, IEquatable<UnicodeSequence>, IEquatable<string>
+    public class UnicodeSequence : IComparable<UnicodeSequence>, IEquatable<UnicodeSequence>, IEquatable<string>, IEqualityComparer<UnicodeSequence>
     {
         private readonly Codepoint[] _codepoints;
         public IEnumerable<Codepoint> Codepoints => _codepoints;
@@ -190,6 +190,11 @@ namespace NeoSmart.Unicode
         public bool Equals(string other)
         {
             return !(other is null) && other.Codepoints().SequenceEqual(_codepoints);
+        }
+
+        public int GetHashCode(UnicodeSequence obj)
+        {
+            return obj.GetHashCode();
         }
     }
 }

--- a/unicode/UnicodeSequence.cs
+++ b/unicode/UnicodeSequence.cs
@@ -158,9 +158,9 @@ namespace NeoSmart.Unicode
             return true;
         }
 
-        public static bool operator ==(UnicodeSequence x, UnicodeSequence y)
+        public static bool operator ==(UnicodeSequence a, UnicodeSequence b)
         {
-            return (x is null && y is null) || (!(x is null || y is null) && x.Equals(y));
+            return (a is null && b is null) || (!(a is null || b is null) && a.Equals(b));
         }
 
         public static bool operator !=(UnicodeSequence a, UnicodeSequence b)
@@ -177,9 +177,9 @@ namespace NeoSmart.Unicode
             return base.Equals(b);
         }
 
-        public bool Equals(UnicodeSequence x, UnicodeSequence y)
+        public bool Equals(UnicodeSequence a, UnicodeSequence b)
         {
-            return (x is null && y is null) || (!(x is null || y is null) && x.Equals(y));
+            return (a is null && b is null) || (!(a is null || b is null) && a.Equals(b));
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
Fixes #4 
Fixes #5 

Also:
* Did the same described in #4 and #5 for `UnicodeSequence`
* Let VS do a code format and import ordering run
* Removed unused imports
* ~~Simplified types `UInt32` => `uint` and `UInt16` => `ushort`~~
* `SingleEmoji` is now a `struct`
* Added more unit tests for `UnicodeSequence` and `SingleEmoji`

**Ready to be reviewed/merged**